### PR TITLE
Allow forms to be added to a container, in additon to normal pop-up use

### DIFF
--- a/source/class/qxl/dialog/Dialog.js
+++ b/source/class/qxl/dialog/Dialog.js
@@ -28,6 +28,8 @@
  */
 qx.Class.define("qxl.dialog.Dialog", {
   extend: qx.ui.window.Window,
+  include: [ qxl.dialog.MDialog ],
+  
   statics: {
     /**
      * for backwards-compability
@@ -50,13 +52,8 @@ qx.Class.define("qxl.dialog.Dialog", {
      * @param type {String} The dialog type to get
      * @return {qxl.dialog.Dialog}
      */
-    getInstanceByType: function(type) {
-      try {
-        return new (qxl.dialog[qx.lang.String.firstUp(type)])();
-      } catch (e) {
-        throw new Error(type + " is not a valid dialog type");
-      }
-    },
+    getInstanceByType: qxl.dialog.MDialog.getInstanceByType,
+
     /**
      * Shortcut for alert dialog
      * @param message {String} The message to display
@@ -220,62 +217,6 @@ qx.Class.define("qxl.dialog.Dialog", {
 
   properties: {
     /**
-     * Callback function that will be called when the user
-     * has interacted with the widget. See sample callback
-     * method supplied in the source code of each dialog
-     * widget.
-     */
-    callback: {
-      check: "Function",
-      nullable: true
-    },
-
-    /**
-     * The context for the callback function
-     */
-    context: {
-      check: "Object",
-      nullable: true
-    },
-
-    /**
-     * A banner image/logo that is displayed on the widget,
-     * if applicable
-     */
-    image: {
-      check: "String",
-      nullable: true,
-      apply: "_applyImage"
-    },
-
-    /**
-     * The message that is displayed
-     */
-    message: {
-      check: "String",
-      nullable: true,
-      apply: "_applyMessage"
-    },
-
-    /**
-     * Whether to allow cancelling the dialog
-     */
-    allowCancel: {
-      check: "Boolean",
-      init: true,
-      event: "changeAllowCancel"
-    },
-
-    /**
-     * Whether to triger the cancel button on pressing the "escape" key
-     * (default: true). Depends on the 'allowCancel' property.
-     */
-    cancelOnEscape: {
-      check: "Boolean",
-      init: true
-    },
-
-    /**
      * Whether the dialog is shown. If true, call the show() method. If false,
      * call the hide() method.
      */
@@ -311,179 +252,12 @@ qx.Class.define("qxl.dialog.Dialog", {
     }
   },
 
-  events: {
-    /**
-     * Dispatched when user clicks on the "OK" Button
-     * @type {String}
-     */
-    ok: "qx.event.type.Event",
-
-    /**
-     * Dispatched when user clicks on the "Cancel" Button
-     * @type {String}
-     */
-    cancel: "qx.event.type.Event"
-  },
-
   members: {
 
     /**
      * A reference to the widget that previously had the focus
      */
     __previousFocus: null,
-
-    /**
-     * The container widget
-     * @var {qx.ui.container.Composite}
-     */
-    _container: null,
-
-    /**
-     * The button pane
-     * @var {qx.ui.basic.Label}
-     */
-    _buttons: null,
-
-    /**
-     * The dialog image
-     * @var {qx.ui.basic.Image}
-     */
-    _image: null,
-
-    /**
-     * The dialog message
-     * @var {qx.ui.basic.Label}
-     */
-    _message: null,
-
-    /**
-     * The OK Button
-     * @var {qx.ui.form.Button}
-     */
-    _okButton: null,
-
-    /**
-     * The cancel button
-     * @var {qx.ui.form.Button}
-     */
-    _cancelButton: null,
-
-    /**
-     * Create the content of the qxl.dialog.
-     * Extending classes must implement this method.
-     */
-    _createWidgetContent: function() {
-      this.error("_createWidgetContent not implemented!");
-    },
-
-    /**
-     * Creates the default container (VBox)
-     * @return {qx.ui.container.Composite}
-     */
-    _createDialogContainer: function() {
-      this._container = new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
-      return this._container;
-    },
-
-    /**
-     * Creates the button pane (HBox)
-     * @return {qx.ui.container.Composite}
-     */
-    _createButtonPane: function() {
-      let buttons = new qx.ui.container.Composite(new qx.ui.layout.HBox(5));
-      buttons.getLayout().setAlignX("center");
-      if (qx.core.Environment.get("module.objectid") === true) {
-        buttons.setQxObjectId("buttons");
-        this.addOwnedQxObject(buttons);
-      }
-      return buttons;
-    },
-
-    /**
-     * Create an OK button
-     * @return {qx.ui.form.Button}
-     */
-    _createOkButton: function(noFocus=false) {
-      let okButton = (this._okButton = new qx.ui.form.Button(this.tr("OK")));
-      okButton.setIcon("qxl.dialog.icon.ok");
-      okButton.getChildControl("icon").set({
-        width: 16,
-        height: 16,
-        scale: true
-      });
-      okButton.setAllowStretchX(false);
-      okButton.addListener("execute", this._handleOk, this);
-      if (!noFocus) {
-        this.addListener("appear", () => okButton.focus());
-      }
-      if (qx.core.Environment.get("module.objectid") === true) {
-        okButton.setQxObjectId("ok");
-        this.getQxObject("buttons").addOwnedQxObject(okButton);
-      }
-      return okButton;
-    },
-
-    /**
-     * Create a cancel button, which is hidden by default and will be shown
-     * if allowCancel property is set to true.
-     * @return {qx.ui.form.Button}
-     */
-    _createCancelButton: function() {
-      let cancelButton = (this._cancelButton = new qx.ui.form.Button(
-        this.tr("Cancel")
-      ));
-      cancelButton.setAllowStretchX(false);
-      cancelButton.setIcon("qxl.dialog.icon.cancel");
-      cancelButton.getChildControl("icon").set({
-        width: 16,
-        height: 16,
-        scale: true
-      });
-      cancelButton.addListener("execute", this._handleCancel, this);
-      this.bind("allowCancel", cancelButton, "visibility", {
-        converter: function(value) {
-          return value ? "visible" : "excluded";
-        }
-      });
-      if (qx.core.Environment.get("module.objectid") === true) {
-        cancelButton.setQxObjectId("cancel");
-        this.getQxObject("buttons").addOwnedQxObject(cancelButton);
-      }
-      return cancelButton;
-    },
-
-    /**
-     * Called when the 'image' property is set
-     * @param value {String} The current value
-     * @param old {String|null} old The previous value
-     * @return {void}
-     */
-    _applyImage: function(value, old) {
-      this._image.setSource(value);
-      this._image.setVisibility(value ? "visible" : "excluded");
-    },
-
-    /**
-     * Called when the 'message' property is set
-     * @param value {String} The current value
-     * @param old {String|null} old The previous value
-     * @return {void}
-     */
-    _applyMessage: function(value, old) {
-      this._message.setValue(value);
-      this._message.setVisibility(value ? "visible" : "excluded");
-    },
-
-    /**
-     * Returns the widgets that is the container of the dialog
-     * @return {qx.ui.core.LayoutItem}
-     */
-    getDialogContainer: function() {
-      if (!this._container) {
-        return this._createDialogContainer();
-      }
-      return this._container;
-    },
 
     /**
      * Show the widget. Overriding methods must call this parent method.
@@ -533,55 +307,6 @@ qx.Class.define("qxl.dialog.Dialog", {
       }
       this.setVisibility("hidden");
       return this;
-    },
-
-    /**
-     * Promise interface method, avoids callbacks
-     * @return {Promise} A promise that resolves with the result of the dialog
-     * action
-     */
-    promise: function() {
-      return new Promise(function(resolve, reject) {
-        this.setCallback(function(value) {
-          this.resetCallback();
-          resolve(value);
-        }.bind(this));
-      }.bind(this));
-    },
-
-    /**
-     * Handle click on ok button. Calls callback with a "true" argument
-     */
-    _handleOk: function() {
-      this.hide();
-      this.fireEvent("ok");
-      if (this.getCallback()) {
-        this.getCallback().call(this.getContext(), true);
-      }
-      this.resetCallback();
-    },
-
-    /**
-     * Handle click on cancel button. Calls callback with
-     * an "undefined" argument
-     */
-    _handleCancel: function() {
-      this.hide();
-      this.fireEvent("cancel");
-      if (this.isAllowCancel() && this.getCallback()) {
-        this.getCallback().call(this.getContext());
-      }
-      this.resetCallback();
-    },
-
-    /**
-     * Handles the press on the 'Escape' key
-     * @param  e {qx.event.type.KeyInput}
-     */
-    _handleEscape: function(e) {
-      if (this.isCancelOnEscape() && e.getKeyCode() === 27 && this.getContentElement() && this.isSeeable()) {
-        this._handleCancel();
-      }
     }
   }
 });

--- a/source/class/qxl/dialog/DialogEmbed.js
+++ b/source/class/qxl/dialog/DialogEmbed.js
@@ -1,0 +1,79 @@
+/* ************************************************************************
+
+   qooxdoo dialog library
+   https://github.com/qooxdoo/qxl.dialog
+
+   Copyright:
+     2007-2019 Christian Boulanger and others
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+
+/**
+ * Base class for dialog widgets
+ * @ignore(qxl.dialog.alert)
+ * @ignore(qxl.dialog.error)
+ * @ignore(qxl.dialog.warning)
+ * @ignore(qxl.dialog.confirm)
+ * @ignore(qxl.dialog.prompt)
+ * @ignore(qxl.dialog.form)
+ * @ignore(qxl.dialog.select)
+ * @ignore(Promise)
+ *
+ */
+qx.Class.define("qxl.dialog.DialogEmbed", {
+  extend: qx.ui.container.Composite,
+  include: [ qxl.dialog.MDialog ],
+  
+  statics: {
+    /**
+     * Returns a dialog instance by type
+     * @param type {String} The dialog type to get
+     * @return {qxl.dialog.Dialog}
+     */
+    getInstanceByType: qxl.dialog.MDialog.getInstanceByType
+  },
+
+  /**
+   * Constructor
+   * @param properties {Map|String|undefined} If you supply a map, all the
+   * corresponding properties will be set. If a string is given, use it
+   * as to set the 'message' property.
+   */
+  construct: function(properties) {
+    this.base(arguments);
+    this.setLayout(new qx.ui.layout.Grow());
+    this._createWidgetContent();
+
+    // set properties from constructor param
+    if (typeof properties == "object") {
+      this.set(properties);
+    } else if (typeof properties == "string") {
+      this.setMessage(properties);
+    }
+    // escape key
+    qx.core.Init.getApplication().getRoot().addListener("keyup", this._handleEscape, this);
+  },
+
+  statics :
+  {
+    /**
+     * Shortcut for form dialog. Cannot be reused.
+     * @param message {String} The message to display
+     * @param formData {Map} Map of form data. See {@link qxl.dialog.Form.formData}
+     * @param callback {Function?} The callback function
+     * @param context {Object?} The context to use with the callback function
+     * @param caption {String?} The caption of the dialog window
+     * @return {qxl.dialog.Form} The widget instance
+     */
+    form: function(message, formData, callback=null, context=null, caption="") {
+      qx.core.Assert.assertMap(formData);
+      return new qxl.dialog.FormEmbed({message, formData, allowCancel: true, callback, context});
+    }
+  }
+});

--- a/source/class/qxl/dialog/FormEmbed.js
+++ b/source/class/qxl/dialog/FormEmbed.js
@@ -16,8 +16,8 @@
 /**
  * A dialog with a form that is constructed on-the-fly
  */
-qx.Class.define("qxl.dialog.Form", {
-  extend: qxl.dialog.Dialog,
+qx.Class.define("qxl.dialog.FormEmbed", {
+  extend: qxl.dialog.DialogEmbed,
   include: [ qxl.dialog.MForm ],
 
   members :

--- a/source/class/qxl/dialog/MDialog.js
+++ b/source/class/qxl/dialog/MDialog.js
@@ -1,0 +1,320 @@
+/* ************************************************************************
+
+   qooxdoo dialog library
+   https://github.com/qooxdoo/qxl.dialog
+
+   Copyright:
+     2007-2019 Christian Boulanger and others
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+
+/**
+ * Mixin that provides base functionality for Window and embedded dialog
+ * @ignore(qxl.dialog.alert)
+ * @ignore(qxl.dialog.error)
+ * @ignore(qxl.dialog.warning)
+ * @ignore(qxl.dialog.confirm)
+ * @ignore(qxl.dialog.prompt)
+ * @ignore(qxl.dialog.form)
+ * @ignore(qxl.dialog.select)
+ * @ignore(Promise)
+ *
+ */
+qx.Mixin.define("qxl.dialog.MDialog", {
+  statics: {
+    /**
+     * Returns a dialog instance by type
+     * @param type {String} The dialog type to get
+     * @return {qxl.dialog.Dialog}
+     */
+    getInstanceByType: function(type) {
+      try {
+        return new (qxl.dialog[qx.lang.String.firstUp(type)])();
+      } catch (e) {
+        throw new Error(type + " is not a valid dialog type");
+      }
+    }
+  },
+
+  properties: {
+    /**
+     * Callback function that will be called when the user
+     * has interacted with the widget. See sample callback
+     * method supplied in the source code of each dialog
+     * widget.
+     */
+    callback: {
+      check: "Function",
+      nullable: true
+    },
+
+    /**
+     * The context for the callback function
+     */
+    context: {
+      check: "Object",
+      nullable: true
+    },
+
+    /**
+     * A banner image/logo that is displayed on the widget,
+     * if applicable
+     */
+    image: {
+      check: "String",
+      nullable: true,
+      apply: "_applyImage"
+    },
+
+    /**
+     * The message that is displayed
+     */
+    message: {
+      check: "String",
+      nullable: true,
+      apply: "_applyMessage"
+    },
+
+    /**
+     * Whether to allow cancelling the dialog
+     */
+    allowCancel: {
+      check: "Boolean",
+      init: true,
+      event: "changeAllowCancel"
+    },
+
+    /**
+     * Whether to triger the cancel button on pressing the "escape" key
+     * (default: true). Depends on the 'allowCancel' property.
+     */
+    cancelOnEscape: {
+      check: "Boolean",
+      init: true
+    }
+  },
+
+  events: {
+    /**
+     * Dispatched when user clicks on the "OK" Button
+     * @type {String}
+     */
+    ok: "qx.event.type.Event",
+
+    /**
+     * Dispatched when user clicks on the "Cancel" Button
+     * @type {String}
+     */
+    cancel: "qx.event.type.Event"
+  },
+
+  members: {
+    /**
+     * The container widget
+     * @var {qx.ui.container.Composite}
+     */
+    _container: null,
+
+    /**
+     * The button pane
+     * @var {qx.ui.basic.Label}
+     */
+    _buttons: null,
+
+    /**
+     * The dialog image
+     * @var {qx.ui.basic.Image}
+     */
+    _image: null,
+
+    /**
+     * The dialog message
+     * @var {qx.ui.basic.Label}
+     */
+    _message: null,
+
+    /**
+     * The OK Button
+     * @var {qx.ui.form.Button}
+     */
+    _okButton: null,
+
+    /**
+     * The cancel button
+     * @var {qx.ui.form.Button}
+     */
+    _cancelButton: null,
+
+    /**
+     * Create the content of the qxl.dialog.
+     * Extending classes must implement this method.
+     */
+    _createWidgetContent: function() {
+      this.error("_createWidgetContent not implemented!");
+    },
+
+    /**
+     * Creates the default container (VBox)
+     * @return {qx.ui.container.Composite}
+     */
+    _createDialogContainer: function() {
+      this._container = new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
+      return this._container;
+    },
+
+    /**
+     * Creates the button pane (HBox)
+     * @return {qx.ui.container.Composite}
+     */
+    _createButtonPane: function() {
+      let buttons = new qx.ui.container.Composite(new qx.ui.layout.HBox(5));
+      buttons.getLayout().setAlignX("center");
+      if (qx.core.Environment.get("module.objectid") === true) {
+        buttons.setQxObjectId("buttons");
+        this.addOwnedQxObject(buttons);
+      }
+      return buttons;
+    },
+
+    /**
+     * Create an OK button
+     * @return {qx.ui.form.Button}
+     */
+    _createOkButton: function(noFocus=false) {
+      let okButton = (this._okButton = new qx.ui.form.Button(this.tr("OK")));
+      okButton.setIcon("qxl.dialog.icon.ok");
+      okButton.getChildControl("icon").set({
+        width: 16,
+        height: 16,
+        scale: true
+      });
+      okButton.setAllowStretchX(false);
+      okButton.addListener("execute", this._handleOk, this);
+      if (!noFocus) {
+        this.addListener("appear", () => okButton.focus());
+      }
+      if (qx.core.Environment.get("module.objectid") === true) {
+        okButton.setQxObjectId("ok");
+        this.getQxObject("buttons").addOwnedQxObject(okButton);
+      }
+      return okButton;
+    },
+
+    /**
+     * Create a cancel button, which is hidden by default and will be shown
+     * if allowCancel property is set to true.
+     * @return {qx.ui.form.Button}
+     */
+    _createCancelButton: function() {
+      let cancelButton = (this._cancelButton = new qx.ui.form.Button(
+        this.tr("Cancel")
+      ));
+      cancelButton.setAllowStretchX(false);
+      cancelButton.setIcon("qxl.dialog.icon.cancel");
+      cancelButton.getChildControl("icon").set({
+        width: 16,
+        height: 16,
+        scale: true
+      });
+      cancelButton.addListener("execute", this._handleCancel, this);
+      this.bind("allowCancel", cancelButton, "visibility", {
+        converter: function(value) {
+          return value ? "visible" : "excluded";
+        }
+      });
+      if (qx.core.Environment.get("module.objectid") === true) {
+        cancelButton.setQxObjectId("cancel");
+        this.getQxObject("buttons").addOwnedQxObject(cancelButton);
+      }
+      return cancelButton;
+    },
+
+    /**
+     * Called when the 'image' property is set
+     * @param value {String} The current value
+     * @param old {String|null} old The previous value
+     * @return {void}
+     */
+    _applyImage: function(value, old) {
+      this._image.setSource(value);
+      this._image.setVisibility(value ? "visible" : "excluded");
+    },
+
+    /**
+     * Called when the 'message' property is set
+     * @param value {String} The current value
+     * @param old {String|null} old The previous value
+     * @return {void}
+     */
+    _applyMessage: function(value, old) {
+      this._message.setValue(value);
+      this._message.setVisibility(value ? "visible" : "excluded");
+    },
+
+    /**
+     * Returns the widgets that is the container of the dialog
+     * @return {qx.ui.core.LayoutItem}
+     */
+    getDialogContainer: function() {
+      if (!this._container) {
+        return this._createDialogContainer();
+      }
+      return this._container;
+    },
+
+    /**
+     * Promise interface method, avoids callbacks
+     * @return {Promise} A promise that resolves with the result of the dialog
+     * action
+     */
+    promise: function() {
+      return new Promise(function(resolve, reject) {
+        this.setCallback(function(value) {
+          this.resetCallback();
+          resolve(value);
+        }.bind(this));
+      }.bind(this));
+    },
+
+    /**
+     * Handle click on ok button. Calls callback with a "true" argument
+     */
+    _handleOk: function() {
+      this.hide();
+      this.fireEvent("ok");
+      if (this.getCallback()) {
+        this.getCallback().call(this.getContext(), true);
+      }
+      this.resetCallback();
+    },
+
+    /**
+     * Handle click on cancel button. Calls callback with
+     * an "undefined" argument
+     */
+    _handleCancel: function() {
+      this.hide();
+      this.fireEvent("cancel");
+      if (this.isAllowCancel() && this.getCallback()) {
+        this.getCallback().call(this.getContext());
+      }
+      this.resetCallback();
+    },
+
+    /**
+     * Handles the press on the 'Escape' key
+     * @param  e {qx.event.type.KeyInput}
+     */
+    _handleEscape: function(e) {
+      if (this.isCancelOnEscape() && e.getKeyCode() === 27 && this.getContentElement() && this.isSeeable()) {
+        this._handleCancel();
+      }
+    }
+  }
+});

--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -1,0 +1,493 @@
+/* ************************************************************************
+
+   qooxdoo dialog library
+   https://github.com/qooxdoo/qxl.dialog
+
+   Copyright:
+     2007-2018 Christian Boulanger and others
+
+   License:
+     LGPL: http://www.gnu.org/licenses/lgpl.html
+     EPL: http://www.eclipse.org/org/documents/epl-v10.php
+     See the LICENSE file in the project's top-level directory for details.
+
+************************************************************************ */
+
+/**
+ * Mixin that provides the functionality for a dialog with a form that
+ * is constructed on-the-fly. Used by the Window-based dialog form,
+ * and by an embedded dialog form
+ *
+ * @require(qxl.dialog.FormRenderer)
+ * @require(qx.util.Serializer)
+ * @require(qx.util.Validate)
+ */
+qx.Mixin.define("qxl.dialog.MForm", {
+  properties: {
+    /**
+     * Data to create a form with multiple fields.
+     * So far implemented:
+     *   TextField / TextArea
+     *   ComboBox
+     *   SelectBox
+     *   RadioGroup
+     *   CheckBox
+     *
+     * <pre>
+     * {
+     *  "username" : {
+     *     'type'  : "TextField",
+     *     'label' : "User Name",
+     *     'value' : ""
+     *   },
+     *   "address" : {
+     *     'type'  : "TextArea",
+     *     'label' : "Address",
+     *     'lines' : 3
+     *   },
+     *   "domain" : {
+     *     'type'  : "SelectBox",
+     *     'label' : "Domain",
+     *     'value' : 1,
+     *     'options' : [
+     *       { 'label' : "Company", 'value' : 0 },
+     *       { 'label' : "Home",    'value' : 1 }
+     *     ]
+     *   },
+     *   "commands" : {
+     *    'type'  : "ComboBox",
+     *     'label' : "Shell command to execute",
+     *     'options' : [
+     *       { 'label' : "ln -s *" },
+     *       { 'label' : "rm -Rf /" }
+     *     ]
+     *   }
+     * }
+     * </pre>
+     *
+     */
+    formData: {
+      check: "Map",
+      nullable: true,
+      event: "changeFormData",
+      apply: "_applyFormData"
+    },
+
+    /**
+     * The model of the result data
+     */
+    model: {
+      check: "qx.core.Object",
+      nullable: true,
+      event: "changeModel"
+    },
+
+    /**
+     * The default width of the column with the field labels
+     */
+    labelColumnWidth: {
+      check: "Integer",
+      nullable: false,
+      init: 100
+    }
+  },
+
+  members: {
+    _formContainer: null,
+    _form: null,
+    _formValidator: null,
+    _formController: null,
+
+    /**
+     * Return the form
+     * @return {qx.ui.form.Form}
+     */
+    getForm: function () {
+      return this._form;
+    },
+
+    /**
+     * Create the main content of the widget
+     */
+    _createWidgetContent: function () {
+      let container = new qx.ui.container.Composite();
+      container.setLayout(new qx.ui.layout.VBox(10));
+
+      let hbox = new qx.ui.container.Composite();
+      hbox.setLayout(new qx.ui.layout.HBox(10));
+      container.add(hbox);
+      this._message = new qx.ui.basic.Label();
+      this._message.setRich(true);
+      this._message.setMinWidth(200);
+      this._message.setAllowStretchX(true);
+      hbox.add(this._message, {
+        flex: 1
+      });
+
+      // wrap fields in form tag to avoid Chrome warnings, see https://github.com/qooxdoo/qxl.dialog/issues/19
+      let formTag = new qxl.dialog.FormTag();
+      this._formContainer = new qx.ui.container.Composite();
+      this._formContainer.setLayout(new qx.ui.layout.Grow());
+      formTag.add(this._formContainer, {flex: 1});
+      container.add(formTag, { flex: 1 });
+
+      // buttons
+      let buttonPane = this._createButtonPane();
+      container.add(buttonPane);
+      let okButton = this._createOkButton();
+      buttonPane.add(okButton);
+      let cancelButton = this._createCancelButton();
+      buttonPane.add(cancelButton);
+
+      this.add(container);
+    },
+
+    /**
+     * Constructs the form on-the-fly
+     * @param formData {Map} The form data map
+     * @param old {Map|null} The old value
+     * @lint ignoreDeprecated(alert,eval)
+     */
+    _applyFormData: function (formData, old) {
+      if (this._formController) {
+        try {
+          this.getModel().removeAllBindings();
+          this._formController.dispose();
+        } catch (e) {
+        }
+      }
+      if (this._form) {
+        try {
+          this._form.getValidationManager().removeAllBindings();
+          this._form.dispose();
+        } catch (e) {
+        }
+      }
+      this._formContainer.removeAll();
+      if (!formData) {
+        return;
+      }
+      if (this.getModel()) {
+        this.getModel().removeAllBindings();
+        this.getModel().dispose();
+      }
+      let modelData = {};
+      for (let key of Object.getOwnPropertyNames(formData)) {
+        modelData[key] = formData[key].value !== undefined ?
+        formData[key].value :
+        null;
+      }
+      let model = qx.data.marshal.Json.createModel(modelData);
+      this.setModel(model);
+      // form
+      this._form = new qx.ui.form.Form();
+      if (qx.core.Environment.get("module.objectid") === true) {
+        if (this.getQxObject("form")) {
+          this.removeOwnedQxObject("form");
+        }
+        this.addOwnedQxObject(this._form, "form");
+      }
+      this._formController = new qx.data.controller.Object(this.getModel());
+      this._onFormReady(this._form);
+      for (let key of Object.getOwnPropertyNames(formData)) {
+        let fieldData = formData[key];
+        let formElement = null;
+        switch (fieldData.type.toLowerCase()) {
+          case "groupheader":
+            this._form.addGroupHeader(fieldData.value);
+            break;
+          case "textarea":
+            formElement = new qx.ui.form.TextArea();
+            formElement.setHeight(fieldData.lines * 16);
+            formElement.setLiveUpdate(true);
+            break;
+          case "textfield":
+            formElement = new qx.ui.form.TextField();
+            if (fieldData.maxLength) {
+             formElement.setMaxLength(fieldData.maxLength);
+            }
+            formElement.setLiveUpdate(true);
+            break;
+          case "datefield":
+          case "date":
+            formElement = new qx.ui.form.DateField();
+            if (fieldData.dateFormat) {
+              formElement.setDateFormat(fieldData.dateFormat);
+            }
+            break;
+          case "passwordfield":
+          case "password":
+            formElement = new qx.ui.form.PasswordField();
+            formElement.getContentElement().setAttribute("autocomplete", "password");
+            break;
+          case "combobox":
+            formElement = new qx.ui.form.ComboBox();
+            fieldData.options.forEach(function (item) {
+              let listItem = new qx.ui.form.ListItem(item.label, item.icon);
+              formElement.add(listItem);
+            });
+            break;
+          case "selectbox":
+            formElement = new qx.ui.form.SelectBox();
+            model = qx.data.marshal.Json.createModel(fieldData.options);
+            new qx.data.controller.List(model, formElement, "label");
+            break;
+          case "radiogroup":
+            formElement = new qx.ui.form.RadioGroup();
+            if (fieldData.orientation) {
+              formElement.setUserData("orientation", fieldData.orientation);
+            }
+            fieldData.options.forEach(function (item) {
+              let radioButton = new qx.ui.form.RadioButton(item.label);
+              radioButton.setUserData(
+              "value",
+              item.value !== undefined ? item.value : item.label
+              );
+              formElement.add(radioButton);
+            }, this);
+            break;
+          case "label":
+            formElement = new qx.ui.form.TextField(); // dummy
+            formElement.setUserData("excluded", true);
+            break;
+          case "checkbox":
+            formElement = new qx.ui.form.CheckBox(fieldData.label);
+            break;
+          case "spinner":
+            formElement = new qx.ui.form.Spinner();
+            if (fieldData.min) {
+              formElement.setMinimum(fieldData.min);
+            }
+            if (fieldData.max) {
+              formElement.setMaximum(fieldData.max);
+            }
+            if (fieldData.step) {
+              formElement.setSingleStep(fieldData.step);
+            }
+            if (fieldData.fractionsDigits) {
+              let fd = fieldData.fractionsDigits;
+              let nf = new qx.util.format.NumberFormat();
+              if (fd.min) {
+                nf.setMinimumFractionDigits(fd.min);
+              }
+              if (fd.max) {
+                nf.setMaximumFractionDigits(fd.max);
+              }
+              formElement.setNumberFormat(nf);
+            }
+            break;
+          default:
+            this.error("Invalid form field type:" + fieldData.type);
+        }
+        formElement.setUserData("key", key);
+        let _this = this;
+        if (typeof fieldData.type == "string") {
+          switch (fieldData.type.toLowerCase()) {
+            case "textarea":
+            case "textfield":
+            case "passwordfield":
+            case "combobox":
+            case "datefield":
+            case "spinner":
+              this._formController.addTarget(formElement, "value", key, true, null, {
+                converter: function (value) {
+                  _this._form.getValidationManager().validate();
+                  return value;
+                }
+              });
+              break;
+            case "checkbox":
+              this._formController.addTarget(formElement, "value", key, true, null);
+              break;
+            case "selectbox":
+              this._formController.addTarget(formElement, "selection", key, true, {
+                converter: qx.lang.Function.bind(function (value) {
+                  let selected = null;
+                  let selectables = this.getSelectables();
+                  selectables.forEach(function (selectable) {
+                    if (selectable.getModel().getValue() === value) {
+                      selected = selectable;
+                    }
+                  }, this);
+                  if (!selected) {
+                    return [selectables[0]];
+                  }
+                  return [selected];
+                }, formElement)
+              }, {
+                converter: qx.lang.Function.bind(function (selection) {
+                  let value = selection[0].getModel().getValue();
+                  return value;
+                }, formElement)
+              });
+              break;
+            case "radiogroup":
+              this._formController.addTarget(formElement, "selection", key, true, {
+                converter: qx.lang.Function.bind(function (value) {
+                  let selectables = this.getSelectables();
+                  let selection = [];
+                  if (value) {
+                    selectables.forEach(function (selectable) {
+                      let sValue = selectable.getUserData("value");
+                      if (sValue === value) {
+                        selection = [selectable];
+                      }
+                    }, this);
+                  }
+                  return selection;
+                }, formElement)
+              }, {
+                converter: function (selection) {
+                  let value = selection[0].getUserData("value");
+                  return value;
+                }
+              });
+              break;
+          }
+        }
+        /**
+         * Validation
+         */
+        let validator = null;
+        if (formElement && fieldData.validation) {
+          // required field
+          if (fieldData.validation.required) {
+            formElement.setRequired(true);
+          }
+          // sync validation
+          if (fieldData.validation.validator) {
+            validator = fieldData.validation.validator;
+            if (typeof validator == "string") {
+              if (qx.util.Validate[validator]) {
+                validator = qx.util.Validate[validator]();
+              } else if (validator.charAt(0) === "/") {
+                validator = qx.util.Validate.regExp(
+                new RegExp(validator.substr(1, validator.length - 2)),
+                fieldData.validation.errorMessage
+                );
+              } else {
+                this.error("Invalid string validator.");
+              }
+            } else if (!(validator instanceof qx.ui.form.validation.AsyncValidator) && typeof validator !== "function") {
+              this.error("Invalid validator.");
+            }
+          }
+          // async validation
+          if (qx.lang.Type.isString(fieldData.validation.proxy) &&
+          qx.lang.Type.isString(fieldData.validation.method)
+          ) {
+            /**
+             * fieldData.validation.proxy
+             * the name of a global variable (or path) to a function that acts as the proxy of
+             * the 'send' or 'execute' function of a preconfigured JsonRpc client. The function
+             * receives the following parameters: service method (string), parameters (array)
+             * and callback (function). It proxies the parameters to the given JsonRpc method and
+             * calls the callback with the result (true if valid, false if not) received from the
+             * server. The JsonRpc service name is preconfigured by the server and cannot be
+             * changed by the client.
+             */
+            // clean
+            let proxy = fieldData.validation.proxy.replace(/;\n/g, "");
+            try {
+              eval("proxy = " + proxy + ";");
+            } catch (e) {
+              this.warn("Invalid proxy name");
+            }
+            if (typeof proxy == "function") {
+              let method = fieldData.validation.method;
+              let message = fieldData.validation.invalidMessage;
+              let validationFunc = function (validatorObj, value) {
+                if (!validatorObj.__asyncInProgress) {
+                  validatorObj.__asyncInProgress = true;
+                  proxy(method, [value], function (valid) {
+                    validatorObj.setValid(valid, message || this.tr("Value is invalid"));
+                    validatorObj.__asyncInProgress = false;
+                  });
+                }
+              };
+              validator = new qx.ui.form.validation.AsyncValidator(validationFunc);
+            }
+          }
+        }
+
+        /**
+         * other widget properties @todo: allow to set all properties
+         */
+        if (fieldData.width !== undefined) {
+          formElement.setWidth(fieldData.width);
+        }
+        if (fieldData.placeholder !== undefined) {
+          formElement.setPlaceholder(fieldData.placeholder);
+        }
+        if (fieldData.enabled !== undefined) {
+          formElement.setEnabled(fieldData.enabled);
+        }
+
+        /**
+         * Events
+         */
+        if (qx.lang.Type.isObject(fieldData.events)) {
+          for (let type in fieldData.events) {
+            try {
+              let func = eval("(" + fieldData.events[type] + ")"); // eval is evil, I know.
+              if (!qx.lang.Type.isFunction(func)) {
+                throw new Error();
+              }
+              formElement.addListener(type, func, formElement);
+            } catch (e) {
+              this.warn("Invalid '" + type + "' event handler for form element '" + key + "'.");
+            }
+          }
+        }
+
+        // Putting it all together
+        let label = fieldData.label;
+        this._form.add(formElement, label, validator);
+        // Add the form elements as objects owned by the form widget
+        if (qx.core.Environment.get("module.objectid") === true) {
+          formElement.setQxObjectId(key);
+          this._form.addOwnedQxObject(formElement);
+        }
+      }
+
+
+      let view = new qxl.dialog.FormRenderer(this._form);
+      view.getLayout().setColumnFlex(0, 0);
+      view.getLayout().setColumnMaxWidth(0, this.getLabelColumnWidth());
+      view.getLayout().setColumnFlex(1, 1);
+      view.setAllowGrowX(true);
+      this._formContainer.add(view);
+      this._form.getValidationManager().validate();
+    },
+
+    /**
+     * Hook for subclasses to do something with the form, for example
+     * in order to attach bindings to the validation manager.
+     * Default behavior: bind the enabled state of the "OK" button to the
+     * validity of the current form.
+     * @param form {qx.ui.form.Form} The form to bind
+     */
+    _onFormReady: function (form) {
+      form.getValidationManager().bind("valid", this._okButton, "enabled", {
+        converter: function (value) {
+          return value || false;
+        }
+      });
+    },
+
+    /**
+     * Handle click on ok button. Calls callback with the result map
+     * @override
+     */
+    _handleOk: function () {
+      this.hide();
+      if (this.getCallback()) {
+        this.getCallback().call(
+        this.getContext(),
+        qx.util.Serializer.toNativeObject(this.getModel())
+        );
+      }
+      this.resetCallback();
+    }
+  }
+});

--- a/source/class/qxl/dialog/demo/Application.js
+++ b/source/class/qxl/dialog/demo/Application.js
@@ -84,6 +84,11 @@ qx.Class.define("qxl.dialog.demo.Application",
               method: "createForm"
             },
             {
+              label: "Embedded Form",
+              id: "formEmbed",
+              method: "createFormEmbedded"
+            },
+            {
               label: "Wizard",
               id: "wizard",
               method: "createWizard"
@@ -345,6 +350,81 @@ qx.Class.define("qxl.dialog.demo.Application",
             };
 
           let form = qxl.dialog.Dialog.form("Please fill in the form", formData).set({caption});
+          form.setQxObjectId("dialog");
+          button.addOwnedQxObject(form);
+          form.promise()
+          .then(result => {
+            this.debug(qx.util.Serializer.toJson(result));
+            return qxl.dialog.Dialog
+              .alert("Thank you for your input. See log for result.")
+              .set({caption: caption + " 2"})
+              .promise();
+          });
+        },
+
+        createFormEmbedded: function (caption, button) {
+          let formData =
+            {
+              "username":
+                {
+                  "type": "TextField",
+                  "label": "User Name",
+                  "value": "",
+                  "validation": {
+                    "required": true
+                  }
+                },
+              "address":
+                {
+                  "type": "TextArea",
+                  "label": "Address",
+                  "lines": 3,
+                  "value": ""
+                },
+              "domain":
+                {
+                  "type": "SelectBox",
+                  "label": "Domain",
+                  "value": 1,
+                  "options": [
+                    {"label": "Company", "value": 0},
+                    {"label": "Home", "value": 1}
+                  ]
+                },
+              "commands":
+                {
+                  "type": "ComboBox",
+                  "label": "Shell command to execute",
+                  "value": "",
+                  "options": [
+                    {"label": "ln -s *"},
+                    {"label": "rm -Rf /"}
+                  ]
+                },
+              "save_details": {
+                "type": "Checkbox",
+                "label": "Save form details",
+                "value": true
+              },
+              "executeDate": {
+                "type": "datefield",
+                "dateFormat": new qx.util.format.DateFormat("dd.MM.yyyy HH:mm"),
+                "value": new Date(),
+                "label": "Execute At"
+              },
+              "area": {
+                "type": "spinner",
+                "label": "Area",
+                "value": 25.5,
+                "min": -10,
+                "max": 100,
+                "step": 0.5,
+                "fractionsDigits": {min: 1, max: 7}
+              }
+            };
+
+          let form = qxl.dialog.DialogEmbed.form("Please fill in the form", formData).set({});
+          this.getRoot().add(form, { left: 400, top: 100 });
           form.setQxObjectId("dialog");
           button.addOwnedQxObject(form);
           form.promise()


### PR DESCRIPTION
Most functionality of Form and Dialog is moved into mixins, allowing that functionality to be included in small wrapper classes that specify the base class. This allows having a wrapper class that extends qx.ui.window.Window as traditional, and also one that extends qx.ui.container.Composite so that a form can be built using this package, and included right inline in an app rather than as a pop-up.
