### PR TITLE
Misc fixes

### DIFF
--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -128,10 +128,11 @@ qx.Mixin.define("qxl.dialog.MForm", {
     },
 
     /**
-     * Function to call just before creating the form's input fields. This
-     * allows additional, non-form widgets to be added. The function is called
-     * one two arguments: the container in which the form fields should be
-     * placed, and the form object itself (this).
+     * Function to call just before creating the form's input fields.
+     * This allows additional, non-form widgets to be added. The
+     * function is called two arguments: the container in which the
+     * form fields should be placed, and the form object itself
+     * (this).
      */
     beforeFormFunction :
     {
@@ -344,6 +345,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
       let hbox = new qx.ui.container.Composite();
       hbox.setLayout(new qx.ui.layout.HBox(10));
       container.add(hbox);
+      container.setUserData("messageHBox", hbox);
       this._message = new qx.ui.basic.Label();
       this._message.setRich(true);
       this._message.setMinWidth(200);
@@ -629,7 +631,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
 
         // Putting it all together
         let label = fieldData.label;
-        label && this._form.add(formElement, label, validator);
+        this._form.add(formElement, label || "", validator);
         // Add the form elements as objects owned by the form widget
         if (qx.core.Environment.get("module.objectid") === true) {
           formElement.setQxObjectId(key);

--- a/source/class/qxl/dialog/MultiColumnFormRenderer.js
+++ b/source/class/qxl/dialog/MultiColumnFormRenderer.js
@@ -161,7 +161,8 @@ qx.Class.define("qxl.dialog.MultiColumnFormRenderer",
          * if the label is null, use the full width for the widget
          * doesn't work yet
          */
-        else if (! names[i])
+        // SINCE IT DOESN'T WORK YET, TEMPORARILY COMMENT IT OUT...
+        else if (false && ! names[i])
         {
           this._add(
             widget,
@@ -170,6 +171,17 @@ qx.Class.define("qxl.dialog.MultiColumnFormRenderer",
               column  : col,
               rowSpan : rowspan,
               colSpan : 2
+            });
+        }
+        // ... AND DO THIS INSTEAD
+        else if (true && ! names[i])
+        {
+          this._add(
+            widget,
+            {
+              row     : row,
+              column  : col + 1,
+              rowSpan : rowspan
             });
         }
         

--- a/source/class/qxl/dialog/MultiColumnFormRenderer.js
+++ b/source/class/qxl/dialog/MultiColumnFormRenderer.js
@@ -158,11 +158,19 @@ qx.Class.define("qxl.dialog.MultiColumnFormRenderer",
         }
         
         /*
-         * if the label is null, use the full width for the widget
-         * doesn't work yet
+         * If the label is null, use the full width for the widget.
+         *
+         * This doesn't work because the first of the two columns (the
+         * label column) has a maxWidth value, and (it seems) the grid
+         * layout isn't able to handle a colspan with a maxWidth in
+         * the first of the two columns and additional space available
+         * in the subsequent column; it still limits the width to the
+         * first column's maxWidth
+         *
+         * Instead, allow a means of using this that is backwards compatible,
+         * should it ever be made to work
          */
-        // SINCE IT DOESN'T WORK YET, TEMPORARILY COMMENT IT OUT...
-        else if (false && ! names[i])
+        else if (item.getUserData("combineWithLabelColumn") && ! names[i])
         {
           this._add(
             widget,
@@ -173,8 +181,11 @@ qx.Class.define("qxl.dialog.MultiColumnFormRenderer",
               colSpan : 2
             });
         }
-        // ... AND DO THIS INSTEAD
-        else if (true && ! names[i])
+
+        /*
+         * Instead, just elide the label
+         */
+        else if (! names[i])
         {
           this._add(
             widget,


### PR DESCRIPTION
- Docu fix
- Provide means to access message hbox (above form) in `beforeFormFunction`
- Allow adding a widget with an empty label. The current implementation just elides the label, but a future, backward-compatibility option allows combining the label and widget columns when there is no label, but as explained in the comment that doesn't currently work.