### PR TITLE
When overriding a method, be sure to do everything important from it

### DIFF
--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -713,6 +713,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
      */
     _handleOk: function () {
       this.hide();
+      this.fireEvent("ok");
       if (this.getCallback()) {
         this.getCallback().call(
         this.getContext(),


### PR DESCRIPTION
Firing the 'ok' event was missing.