### PR TITLE
Fix typo in documentation

### DIFF
--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -211,7 +211,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
      *
      * @param handlers {Map}
      *   Handler functions for this form element. `initElement` is
-     *   mandatory; `attToFormController` and `postProcess` are
+     *   mandatory; `addToFormController` and `postProcess` are
      *   optional.
      *
      *   All handlers are called in the context of the


### PR DESCRIPTION
I think there is a typo in the documentation.