### PR TITLE
`properties` should be optional

### DIFF
--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -348,7 +348,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
      * Create the main content of the widget
      * @param properties
      */
-    _createWidgetContent: function (properties) {
+    _createWidgetContent: function (properties = {}) {
       /*
        * Handle properties that must be set before _applyFormData
        */

--- a/source/class/qxl/dialog/MForm.js
+++ b/source/class/qxl/dialog/MForm.js
@@ -347,7 +347,7 @@ qx.Mixin.define("qxl.dialog.MForm", {
     /**
      * Create the main content of the widget
      */
-    _createWidgetContent: function (properties) {
+    _createWidgetContent: function (properties = {}) {
       /*
        * Handle properties that must be set before _applyFormData
        */


### PR DESCRIPTION
I rebased from upstream and contrary to yesterday's discussion, it turns out there's little difference; just this one change. @cboulanger please test this with your app, make sure there are no other problems, and then I suggest we release a new version.