### PR TITLE
For qooxdoo 8.0's new class/property system, remove property `show`

### DIFF
--- a/source/class/qxl/dialog/Dialog.js
+++ b/source/class/qxl/dialog/Dialog.js
@@ -260,17 +260,6 @@ qx.Class.define("qxl.dialog.Dialog", {
 
   properties: {
     /**
-     * Whether the dialog is shown. If true, call the show() method. If false,
-     * call the hide() method.
-     */
-    show: {
-      check: "Boolean",
-      nullable: true,
-      event: "changeShow",
-      apply: "_applyShow",
-    },
-
-    /**
      * Whether to block the ui while the widget is displayed
      */
     useBlocker: {


### PR DESCRIPTION
The new class/property system uses the same namespace for members and properties. This means that the same name can't be used in the `members` section and the `properties` section of a class configuration. In Dialog.js, the member method `show` and the property `show` are both defined, so one of them has to go. The property `show` is never used wtihin qxl.dialog, and replacing its use in any app that happens to make use of it is a trivial affair, so the property is hereby removed.